### PR TITLE
Fixed missing workSkill in gloomy dress patch.

### DIFF
--- a/1.6/Gloomy Dress/Patches/gloomy dress vanity table.xml
+++ b/1.6/Gloomy Dress/Patches/gloomy dress vanity table.xml
@@ -9,6 +9,7 @@
           <li>Ferny_VanityTable</li>
         </recipeUsers>
         <researchPrerequisite Inherit="False">Ferny_VanityTable</researchPrerequisite>
+        <workSkill>Crafting</workSkill>
       </recipeMaker>
     </value>
   </Operation>


### PR DESCRIPTION
Fixed missing workSkill in gloomy dress patch, causes them to be crafted with error log and shooting skill used to determine quality.