### PR TITLE
Various Fixes

### DIFF
--- a/1.6/Patches/Pants_No_Medieval_Overhaul.xml
+++ b/1.6/Patches/Pants_No_Medieval_Overhaul.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Make Pants Craftable in Medieval without Medieval Overhaul (There's no pants otherwise) -->
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Medieval Overhaul</li>
+		</mods>
+		<nomatch Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName="Apparel_Pants"]/recipeMaker/researchPrerequisite</xpath>
+			<value>
+				<researchPrerequisite>LemonSkin_RusticClothing</researchPrerequisite>
+			</value>
+		</nomatch>
+	</Operation>
+
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -91,6 +91,8 @@
     <li>dress.cinderella</li>
     <li>cat.imperial.attires</li>
     <li>smiley.faced.mask</li>
+    <li>BotchJob.divineorder</li>
+    <li>River.Tribal.Mittens</li>
     <!-- Fix conflict with Too Many Mods -->
     <li>Wara.toomanymods</li>
   </loadAfter>

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -96,6 +96,8 @@
     <li IfModActive="zal.bananasuit">Mods/Banana Suit</li>
     <li IfModActive="dress.cinderella">Mods/Cinderella Apparel</li>
     <li IfModActive="cat.imperial.attires">Mods/Imperial Attires</li>
+    <li IfModActive="BotchJob.divineorder">Mods/Divine Order</li>
+    <li IfModActive="River.Tribal.Mittens">Mods/River's Tribal Mittens</li>
     <!-- <li IfModActive="smiley.faced.mask">Mods/Smiley Face Mask</li> -->
   </v1.6>
 </loadFolders>

--- a/Mods/Divine Order/Patches/Divine_Order.xml
+++ b/Mods/Divine Order/Patches/Divine_Order.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Change Research Requirement -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ResearchProjectDef[defName = "BotchJob_DivineOrderSmithing"]/prerequisites/li[text()="ComplexClothing"]</xpath>
+		<value>
+			<li>LemonSkin_RusticClothing</li>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Mods/Prisoner Jumpsuits/Patches/LemonSkin_PrisonerJumpsuits.xml
+++ b/Mods/Prisoner Jumpsuits/Patches/LemonSkin_PrisonerJumpsuits.xml
@@ -49,16 +49,4 @@
       </value>
     </match>
   </Operation>
-  <!-- OCARINA_PrisonerJumpsuit_Blue -->
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="OCARINA_PrisonerJumpsuit_Blue"]/statBases</xpath>
-  </Operation>
-  <!-- OCARINA_PrisonerJumpsuit_Orange -->
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="OCARINA_PrisonerJumpsuit_Orange"]/statBases</xpath>
-  </Operation>
-  <!-- OCARINA_PrisonerJumpsuit_Red -->
-  <Operation Class="PatchOperationRemove">
-    <xpath>Defs/ThingDef[defName="OCARINA_PrisonerJumpsuit_Red"]/statBases</xpath>
-  </Operation>
 </Patch>

--- a/Mods/River's Tribal Mittens/Patches/Rivers_Tribal_Mittens.xml
+++ b/Mods/River's Tribal Mittens/Patches/Rivers_Tribal_Mittens.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Change Naming -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName = "River_Tribal_mittens"]/label</xpath>
+		<value>
+			<label>tribal mittens</label>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName = "River_Tribal_mittens"]/description</xpath>
+		<value>
+			<description>A pair of mittens crafted using neolithic tools. While it may look primitive, it is effective at insulating the wearer.</description>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Mods/Vanilla Factions Expanded - Medieval 2/Core/Patches/VFEM2_LeatherBoilpot.xml
+++ b/Mods/Vanilla Factions Expanded - Medieval 2/Core/Patches/VFEM2_LeatherBoilpot.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
-	<!-- Change Research Requirement -->
+	<!-- Change Research Requirement Without Medieval Overhaul -->
 
-	<Operation Class="PatchOperationReplace">
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Medieval Overhaul</li>
+		</mods>
+		<nomatch Class="PatchOperationReplace">
 		<xpath>/Defs/ThingDef[defName = "VFEM2_LeatherBoilpot"]/researchPrerequisites/li[text()="ComplexClothing"]</xpath>
 		<value>
 			<li>LemonSkin_RusticClothing</li>
 		</value>
+		</nomatch>
 	</Operation>
 
 </Patch>

--- a/Mods/Vanilla Factions Expanded - Medieval 2/Core/Patches/VFEM2_LeatherBoilpot.xml
+++ b/Mods/Vanilla Factions Expanded - Medieval 2/Core/Patches/VFEM2_LeatherBoilpot.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- Change Research Requirement -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>/Defs/ThingDef[defName = "VFEM2_LeatherBoilpot"]/researchPrerequisites/li[text()="ComplexClothing"]</xpath>
+		<value>
+			<li>LemonSkin_RusticClothing</li>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
- Core: Added a conditional patch if Medieval Overhaul is not loaded to change the research requirement of Pants to Rustic Clothing.  Note: This is because there are no pants in medieval overwise.  Also category and spawn tags are unchanged, I noticed other medieval available attire from VE had industrial tags so I left them unchanged.
- Divine Order: Changed the research requirement from Complex Clothing to Rustic Clothing.
- Prisoner Jumpsuits: Removed the patches for removing the stats from coloured prisoner outfits as those no longer exist causing errors.
- River's Tribal Mittens: Changed the label to Tribal Mittens to differentiate it from the renamed Vanilla Expanded Apparel Gloves/Mittens.  Also changed the description to match Vanilla Expand Apparel's style as its more descriptive than the original text.
- Vanilla Factions Expanded Medieval 2: Changed Leather Boilpot's research requirement from Complex Clothing to Rustic Clothing.