### PR TITLE
Skip leather boilpot rustic swap when ComplexClothing is already gone.

### DIFF
--- a/Mods/Vanilla Factions Expanded - Medieval 2/Core/Patches/VFEM2_LeatherBoilpot.xml
+++ b/Mods/Vanilla Factions Expanded - Medieval 2/Core/Patches/VFEM2_LeatherBoilpot.xml
@@ -2,16 +2,20 @@
 <Patch>
 
 	<!-- Change Research Requirement Without Medieval Overhaul -->
+	<!-- Skip if another mod (e.g. Progression: Production) already replaced ComplexClothing. -->
 
 	<Operation Class="PatchOperationFindMod">
 		<mods>
 			<li>Medieval Overhaul</li>
 		</mods>
-		<nomatch Class="PatchOperationReplace">
-		<xpath>/Defs/ThingDef[defName = "VFEM2_LeatherBoilpot"]/researchPrerequisites/li[text()="ComplexClothing"]</xpath>
-		<value>
-			<li>LemonSkin_RusticClothing</li>
-		</value>
+		<nomatch Class="PatchOperationConditional">
+			<xpath>/Defs/ThingDef[defName = "VFEM2_LeatherBoilpot"]/researchPrerequisites/li[text()="ComplexClothing"]</xpath>
+			<match Class="PatchOperationReplace">
+				<xpath>/Defs/ThingDef[defName = "VFEM2_LeatherBoilpot"]/researchPrerequisites/li[text()="ComplexClothing"]</xpath>
+				<value>
+					<li>LemonSkin_RusticClothing</li>
+				</value>
+			</match>
 		</nomatch>
 	</Operation>
 


### PR DESCRIPTION
Attire tries to swap the boilpot from Complex Clothing to Rustic Clothing, but Production already moved it to Patchleather, so the swap finds nothing and logs an error.

I don't use MO so this error occurs.
Everything still works, this just ensure the red error doesn't pop.